### PR TITLE
fix(cleanup): inactivate all deployment related to PR environment

### DIFF
--- a/gitsrc/gitsrc.go
+++ b/gitsrc/gitsrc.go
@@ -21,7 +21,7 @@ var ErrNotFound = errors.New("gitsrc: key not found")
 var ErrNotBranch = errors.New("gitsrc: ref is not a branch")
 
 // FromCurrentDir tries to open $PWD as the git repo.
-func FromCurrentDir(*cli.Context) (altsrc.InputSourceContext, error) { //nolint:ireturn
+func FromCurrentDir(*cli.Context) (altsrc.InputSourceContext, error) { //nolint:nolintlint,ireturn
 	r, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
 
 	return &gitSource{r}, err
@@ -89,7 +89,7 @@ func (x *gitSource) IntSlice(name string) ([]int, error) {
 	return nil, ErrNotSupported
 }
 
-func (x *gitSource) Generic(name string) (cli.Generic, error) { //nolint:ireturn
+func (x *gitSource) Generic(name string) (cli.Generic, error) { //nolint:nolintlint,ireturn
 	return nil, ErrNotSupported
 }
 


### PR DESCRIPTION
Ensure cleanup of pull request related deployments by listing based on environment

Previously, listing GitHub deployments by git ref only worked with the ref used to create the deployment.
However, as the pull request ref can be a branch or a sha, there was a risk of failing to clean up some deployments.
To address this issue, we have updated the deployment listing to be based on the deployment's environment.
This ensures that we don't overlook any deployment related to the pull request, and can properly inactivate them as needed.