### PR TITLE
feat: add option to ignore missing deployment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - goheader
     - goimports
     - gosec
-    - ifshort
     - importas
     - ireturn
     - lll

--- a/commands.go
+++ b/commands.go
@@ -94,6 +94,10 @@ var Commands = []cli.Command{
 				Name:  "pr, pull-request",
 				Usage: "Limit cleanup to one or more PRs",
 			},
+			cli.BoolFlag{
+				Name:  "ignore-missing",
+				Usage: "Don't consider it a failure if no deployment is found",
+			},
 		},
 	},
 }

--- a/flake.lock
+++ b/flake.lock
@@ -33,16 +33,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677593406,
-        "narHash": "sha256-Bb9yHYj1Ut78eFqUs+qKsnvLT1YX0GKhWkVuHlJa+tE=",
+        "lastModified": 1689656810,
+        "narHash": "sha256-YCUiZ4I7c6iaw0wcQOMxXvgA+KXg2OHVCIR+YqffUWs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da9e1809cd89f6d6a45a8c639436b9a6471ef004",
+        "rev": "d87ecca36cb85c6438cf41c928e6c59fd3d88b12",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-22.11",
+        "ref": "release-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       with pkgs;
       {
         devShell = github-deploy.devShell;
-        packages.${name} = github-deploy;
+        packages.${name} = github-deploy.github-deploy;
         defaultPackage = github-deploy.defaultPackage;
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
       url = "github:edolstra/flake-compat";
       flake = false;
     };
-    nixpkgs.url = "github:nixos/nixpkgs/release-22.11";
+    nixpkgs.url = "github:nixos/nixpkgs/release-23.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
For the `cleanup` command, when no deployment is found for a given PR, the command fails.

When running `cleanup` with the `--ignore-missing` flag, the command will ignore any missing deployment and just print a warning.