### PR TITLE
fix: expose cleanup errors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.19' ]
+        go: [ '1.22' ]
     steps:
 
     - name: Set up Go ${{ matrix.go }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - uses: actions/setup-go@v5
         with:
-          version: v1.51.2
+          go-version: 1.22
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.58.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,24 +3,21 @@ name: goreleaser
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
-      -
-        name: Run GoReleaser
+          go-version: 1.22
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest

--- a/command/cleanup.go
+++ b/command/cleanup.go
@@ -36,6 +36,7 @@ func CmdCleanup(c *cli.Context) (err error) {
 	} else {
 		// undeploy all closed pull requests
 		var deployed []string
+
 		deployed, err = listDeployedPullRequests(listScript)
 		if err != nil {
 			return err
@@ -48,10 +49,13 @@ func CmdCleanup(c *cli.Context) (err error) {
 		if err != nil {
 			return err
 		}
+
 		openPRs := make([]string, len(prs))
+
 		for i, pr := range prs {
 			openPRs[i] = fmt.Sprintf("pr-%d", *pr.Number)
 		}
+
 		log.Println("open PRs:", openPRs)
 
 		// Now get a list of all the deployed PRs that are not open
@@ -72,7 +76,9 @@ func CmdCleanup(c *cli.Context) (err error) {
 		pullRequestID, err := strconv.Atoi(name)
 		if err != nil {
 			log.Println("Unable to parse pull request id: ", name)
+
 			lastErr = err
+
 			continue
 		}
 
@@ -83,7 +89,9 @@ func CmdCleanup(c *cli.Context) (err error) {
 		err = cmd.Run()
 		if err != nil {
 			log.Println("undeploy error: ", err)
+
 			lastErr = err
+
 			continue
 		}
 

--- a/command/cleanup_test.go
+++ b/command/cleanup_test.go
@@ -1,7 +1,0 @@
-package command_test
-
-import "testing"
-
-func TestCmdCleanup(t *testing.T) {
-	// Write your code here
-}

--- a/command/please_test.go
+++ b/command/please_test.go
@@ -2,6 +2,6 @@ package command_test
 
 import "testing"
 
-func TestCmdPlease(t *testing.T) {
+func TestCmdPlease(_ *testing.T) {
 	// Write your code here
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730120390,
-        "narHash": "sha256-gGal/6jwTQidqtv7TydoPAD5gYEYYgNKCOBShstBV1s=",
+        "lastModified": 1731916565,
+        "narHash": "sha256-Z2RIYB74UqvxtIaFydZA0vrJViQRYKcenobgPbGzueY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d30a86d3f00ae9c1e13bb5ca356c468b46466eff",
+        "rev": "875178e2432b8a0cace5a190450f6ba63157dd12",
         "type": "github"
       },
       "original": {
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/gitsrc/gitsrc.go
+++ b/gitsrc/gitsrc.go
@@ -69,34 +69,34 @@ func (x *gitSource) String(name string) (string, error) {
 
 // These are implemented to satisfy the altsrc.InputSourceContext interface
 
-func (x *gitSource) Int(name string) (int, error) {
+func (x *gitSource) Int(_ string) (int, error) {
 	return 0, ErrNotSupported
 }
 
-func (x *gitSource) Duration(name string) (time.Duration, error) {
+func (x *gitSource) Float64(_ string) (float64, error) {
 	return 0, ErrNotSupported
 }
 
-func (x *gitSource) Float64(name string) (float64, error) {
+func (x *gitSource) Duration(_ string) (time.Duration, error) {
 	return 0, ErrNotSupported
 }
 
-func (x *gitSource) StringSlice(name string) ([]string, error) {
+func (x *gitSource) StringSlice(_ string) ([]string, error) {
 	return nil, ErrNotSupported
 }
 
-func (x *gitSource) IntSlice(name string) ([]int, error) {
+func (x *gitSource) IntSlice(_ string) ([]int, error) {
 	return nil, ErrNotSupported
 }
 
-func (x *gitSource) Generic(name string) (cli.Generic, error) { //nolint:nolintlint,ireturn
+func (x *gitSource) Generic(_ string) (cli.Generic, error) { //nolint:nolintlint,ireturn
 	return nil, ErrNotSupported
 }
 
-func (x *gitSource) Bool(name string) (bool, error) {
+func (x *gitSource) Bool(_ string) (bool, error) {
 	return false, ErrNotSupported
 }
 
-func (x *gitSource) BoolT(name string) (bool, error) {
+func (x *gitSource) BoolT(_ string) (bool, error) {
 	return false, ErrNotSupported
 }

--- a/main.go
+++ b/main.go
@@ -26,6 +26,5 @@ func main() {
 
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal("ERROR:", err)
-		os.Exit(1)
 	}
 }


### PR DESCRIPTION
If anything fails during the cleanup, expose the error to the end-user by changing the exit status.

Fixes #59 